### PR TITLE
Version 0.0.4

### DIFF
--- a/app_config_for.gemspec
+++ b/app_config_for.gemspec
@@ -4,7 +4,7 @@ require_relative "lib/app_config_for/version"
 
 Gem::Specification.new do |spec|
   spec.name = "app_config_for"
-  spec.version = AppConfigFor::VERSION
+  spec.version = AppConfigFor.version
   spec.authors = ["Frank Hall"]
   spec.email = ["ChapterHouse.Dune@gmail.com"]
 
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'activesupport', '~> 7.0'
+  spec.add_dependency 'activesupport', '>= 5.0', '< 8'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 

--- a/lib/app_config_for/gem_version.rb
+++ b/lib/app_config_for/gem_version.rb
@@ -1,0 +1,16 @@
+module AppConfigFor
+
+  def self.gem_version
+    Gem::Version.new(VERSION::STRING)
+  end
+
+  module VERSION
+    MAJOR = 0
+    MINOR = 0
+    TINY  = 4
+    PRE = 0
+
+    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  end
+
+end

--- a/lib/app_config_for/legacy_support.rb
+++ b/lib/app_config_for/legacy_support.rb
@@ -1,0 +1,45 @@
+require 'active_support/core_ext/string/inflections'
+name = File.basename(__dir__).classify
+STDERR.puts "#{name}: Warning! Outdated version of ActiveSupport active! To avoid security issues, please upgrade your version of ActiveSupport to at least 6.1.4."
+if ActiveSupport.gem_version < Gem::Version.new('6.1.0')
+  puts "#{name}: Loading legacy support for ActiveSupport version #{ActiveSupport.gem_version}."
+
+  # Quick and dirty backport. This won't be here long. Just enough to support AppConfigFor during some legacy upgrades.
+  require "active_support/string_inquirer"
+  require "erb"
+  require "yaml"
+
+  module ActiveSupport
+    class EnvironmentInquirer < StringInquirer
+
+      Environments = %w(development test production)
+
+      def initialize(env)
+        super(env)
+        Environments.each { |e| instance_variable_set(:"@#{e}", env == e) }
+      end
+
+      Environments.each { |e| define_method("#{e}?") { instance_variable_get("@#{e}") }}
+    end
+
+    class ConfigurationFile
+      def initialize(file_name)
+        @file_name = file_name
+        @config = File.read(file_name)
+        warn(file_name + ' contains invisible non-breaking spaces.') if @config.match?("\u00A0")
+      end
+
+      def self.parse(file_name)
+        new(file_name).parse
+      end
+
+      def parse
+        YAML.load(ERB.new(@config).result) || {}
+      rescue Psych::SyntaxError => e
+        raise "YAML syntax error occurred while parsing #{@file_name}. Error: #{e.message}"
+      end
+    end
+
+  end
+
+end

--- a/lib/app_config_for/version.rb
+++ b/lib/app_config_for/version.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
+require_relative "gem_version"
 
 module AppConfigFor
-  VERSION = "0.0.3"
+
+  def self.version
+    gem_version
+  end
+
 end


### PR DESCRIPTION
Fixed bug where internal exception was being reported as a LoadError.
Added config_name override.
Additional config directory support
Auto add of gem config directory to config directories if module seems to be a gem.
Different version handling
Legacy support for ActiveSupport >= 5.0 < 6.1.4